### PR TITLE
Deprecate partially templated specifications on class level in topic statistics collector

### DIFF
--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -94,7 +94,7 @@ class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
 {};
 
 /**
- * Class used to measure the received messsage, tparam T, age from a ROS2 subscriber.
+ * Class used to measure the received message, tparam T, age from a ROS2 subscriber.
  *
  * @tparam T the message type to receive from the subscriber / listener
 */
@@ -144,7 +144,7 @@ public:
   }
 
   /**
-   * Return messge age metric unit
+   * Return message age metric unit
    *
    * @return a string representing messager age metric unit
    */
@@ -166,7 +166,7 @@ protected:
 };
 
 /**
- * Class used to measure the received messsage age from a ROS2 subscriber.
+ * Class used to measure the received message age from a ROS2 subscriber.
 */
 template<>
 class ReceivedMessageAgeCollector<
@@ -210,9 +210,9 @@ public:
   }
 
   /**
-   * Return messge age metric unit
+   * Return message age metric unit
    *
-   * @return a string representing messager age metric unit
+   * @return a string representing message age metric unit
    */
   std::string GetMetricUnit() const override
   {

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -104,8 +104,7 @@ class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
 template<typename T>
 class
   [[deprecated("Don't use templated version of the ReceivedMessageAgeCollector, use"
-  "libstatistics_collector::ReceivedMessageAgeCollector with rmw_message_info_t parameter in the"
-  "OnMessageReceived callback")]]
+  "libstatistics_collector::ReceivedMessageAgeCollector alias instead")]]
   ReceivedMessageAgeCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<T>
 {

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -88,6 +88,9 @@ struct TimeStamp<M, typename std::enable_if<HasHeader<M>::value>::type>
 
 /**
  * Primary specialization class template until deprecated templated class is phased out
+ * @warning Don't use templated version of the ReceivedMessageAgeCollector, use
+ * libstatistics_collector::ReceivedMessageAgeCollector alias with rmw_message_info_t
+ * parameter in the OnMessageReceived callback
  */
 template<typename T = rmw_message_info_t, typename Enable = void>
 class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
@@ -99,11 +102,18 @@ class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
  * @tparam T the message type to receive from the subscriber / listener
 */
 template<typename T>
-class ReceivedMessageAgeCollector<
-    T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
+class
+  [[deprecated("Don't use templated version of the ReceivedMessageAgeCollector, use"
+  "libstatistics_collector::ReceivedMessageAgeCollector with rmw_message_info_t parameter in the"
+  "OnMessageReceived callback")]]
+  ReceivedMessageAgeCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<T>
 {
 public:
+  /**
+   * Construct a ReceivedMessageAgeCollector object.
+   *
+   */
   ReceivedMessageAgeCollector() = default;
 
   virtual ~ReceivedMessageAgeCollector() = default;
@@ -114,8 +124,6 @@ public:
   * @param received_message the message to calculate age of.
   * @param now_nanoseconds time the message was received in nanoseconds
   */
-  [[deprecated("Don't use ReceivedMessageAgeCollector with type T, use rmw_message_info_t"
-  "with an untyped ReceivedMessageAgeCollector<>")]]
   void OnMessageReceived(
     const T & received_message,
     const rcl_time_point_value_t now_nanoseconds) override
@@ -177,7 +185,7 @@ class ReceivedMessageAgeCollector<
 public:
   ReceivedMessageAgeCollector() = default;
 
-  virtual ~ReceivedMessageAgeCollector() = default;
+  ~ReceivedMessageAgeCollector() override = default;
 
   /**
   * Handle a new incoming message. Calculate message age if timestamps in message info are valid.
@@ -232,6 +240,9 @@ protected:
 };
 
 }  // namespace topic_statistics_collector
+
+using ReceivedMessageAgeCollector = topic_statistics_collector::ReceivedMessageAgeCollector<>;
+
 }  // namespace libstatistics_collector
 
 #endif  // LIBSTATISTICS_COLLECTOR__TOPIC_STATISTICS_COLLECTOR__RECEIVED_MESSAGE_AGE_HPP_

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -35,6 +35,9 @@ constexpr const int64_t kUninitializedTime{0};
 
 /**
  * Primary specialization class template until deprecated templated class is phased out
+ * @warning Don't use templated version of the ReceivedMessagePeriodCollector, use
+ * libstatistics_collector::ReceivedMessagePeriodCollector alias with rmw_message_info_t
+ * parameter in the OnMessageReceived callback
  */
 template<typename T = rmw_message_info_t, typename Enable = void>
 class ReceivedMessagePeriodCollector : public TopicStatisticsCollector<T>
@@ -47,8 +50,11 @@ class ReceivedMessagePeriodCollector : public TopicStatisticsCollector<T>
  * @tparam T the message type to receive from the subscriber / listener
 */
 template<typename T>
-class ReceivedMessagePeriodCollector<
-    T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
+class
+  [[deprecated("Don't use templated version of the ReceivedMessagePeriodCollector, use"
+  "libstatistics_collector::ReceivedMessagePeriodCollector with rmw_message_info_t parameter in the"
+  "OnMessageReceived callback")]]
+  ReceivedMessagePeriodCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<T>
 {
 public:
@@ -70,8 +76,6 @@ public:
    * @param received_message
    * @param now_nanoseconds time the message was received in nanoseconds
    */
-  [[deprecated("Don't use ReceivedMessagePeriodCollector with type T, use rmw_message_info_t"
-  "with an untyped ReceivedMessagePeriodCollector<>")]]
   void OnMessageReceived(const T & received_message, const rcl_time_point_value_t now_nanoseconds)
   override RCPPUTILS_TSA_REQUIRES(mutex_)
   {
@@ -143,7 +147,8 @@ private:
 };
 
 template<>
-class ReceivedMessagePeriodCollector<rmw_message_info_t,
+class ReceivedMessagePeriodCollector<
+    rmw_message_info_t,
     std::enable_if_t<std::is_same<rmw_message_info_t, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<>
 {
@@ -157,7 +162,7 @@ public:
     ResetTimeLastMessageReceived();
   }
 
-  virtual ~ReceivedMessagePeriodCollector() = default;
+  ~ReceivedMessagePeriodCollector() override = default;
 
   /**
    * Handle a message received and measure its received period. This member is thread safe and acquires
@@ -237,6 +242,9 @@ private:
 };
 
 }  // namespace topic_statistics_collector
+
+using ReceivedMessagePeriodCollector = topic_statistics_collector::ReceivedMessagePeriodCollector<>;
+
 }  // namespace libstatistics_collector
 
 #endif  // LIBSTATISTICS_COLLECTOR__TOPIC_STATISTICS_COLLECTOR__RECEIVED_MESSAGE_PERIOD_HPP_

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -52,8 +52,7 @@ class ReceivedMessagePeriodCollector : public TopicStatisticsCollector<T>
 template<typename T>
 class
   [[deprecated("Don't use templated version of the ReceivedMessagePeriodCollector, use"
-  "libstatistics_collector::ReceivedMessagePeriodCollector with rmw_message_info_t parameter in the"
-  "OnMessageReceived callback")]]
+  "libstatistics_collector::ReceivedMessagePeriodCollector alias instead")]]
   ReceivedMessagePeriodCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<T>
 {

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -41,7 +41,7 @@ class ReceivedMessagePeriodCollector : public TopicStatisticsCollector<T>
 {};
 
 /**
- * Class used to measure the received messsage, tparam T, period from a ROS2 subscriber. This class
+ * Class used to measure the received message, tparam T, period from a ROS2 subscriber. This class
  * is thread safe and acquires a mutex when the member OnMessageReceived is executed.
  *
  * @tparam T the message type to receive from the subscriber / listener

--- a/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
@@ -32,6 +32,9 @@ namespace topic_statistics_collector
 
 /**
  * Primary specialization class template until deprecated templated class is phased out
+ * @warning Don't use templated version of the TopicStatisticsCollector, use
+ * libstatistics_collector::TopicStatisticsCollector alias with rmw_message_info_t parameter in
+ * the OnMessageReceived callback
  */
 template<typename T = rmw_message_info_t, typename Enable = void>
 class TopicStatisticsCollector : public collector::Collector
@@ -43,8 +46,11 @@ class TopicStatisticsCollector : public collector::Collector
  * @tparam T the ROS2 message type to collect
  */
 template<typename T>
-class TopicStatisticsCollector<
-    T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
+class
+  [[deprecated("Don't use templated version of the TopicStatisticsCollector, use"
+  "libstatistics_collector::TopicStatisticsCollector with rmw_message_info_t parameter in the"
+  "OnMessageReceived callback")]]
+  TopicStatisticsCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public collector::Collector
 {
 public:
@@ -60,8 +66,6 @@ public:
    * following 1). the time provided is strictly monotonic 2). the time provided uses the same source
    * as time obtained from the message header.
    */
-  [[deprecated("Don't use TopicStatisticsCollector with type T, use rmw_message_info_t"
-  "with an untyped TopicStatisticsCollector<>")]]
   virtual void OnMessageReceived(
     const T & received_message,
     const rcl_time_point_value_t now_nanoseconds) = 0;
@@ -78,15 +82,16 @@ class TopicStatisticsCollector<rmw_message_info_t,
 public:
   TopicStatisticsCollector() = default;
 
-  virtual ~TopicStatisticsCollector() = default;
+  ~TopicStatisticsCollector() override = default;
 
   /**
    * Handle receiving a single message of type rmw_message_info_t.
    *
    * @param received_message rmw_message_info_t the ROS2 message type to collect
-   * @param now_nanoseconds nanoseconds the time the message was received. Any metrics using this time assumes the
-   * following 1). the time provided is strictly monotonic 2). the time provided uses the same source
-   * as time obtained from the message header.
+   * @param now_nanoseconds nanoseconds the time the message was received.
+   * Any metrics using this time assumes the following:
+   * 1). the time provided is strictly monotonic
+   * 2). the time provided uses the same source as time obtained from the message header.
    */
   virtual void OnMessageReceived(
     const rmw_message_info_t & received_message,
@@ -94,6 +99,9 @@ public:
 };
 
 }  // namespace topic_statistics_collector
+
+using TopicStatisticsCollector = topic_statistics_collector::TopicStatisticsCollector<>;
+
 }  // namespace libstatistics_collector
 
 #endif  // LIBSTATISTICS_COLLECTOR__TOPIC_STATISTICS_COLLECTOR__TOPIC_STATISTICS_COLLECTOR_HPP_

--- a/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
@@ -48,8 +48,7 @@ class TopicStatisticsCollector : public collector::Collector
 template<typename T>
 class
   [[deprecated("Don't use templated version of the TopicStatisticsCollector, use"
-  "libstatistics_collector::TopicStatisticsCollector with rmw_message_info_t parameter in the"
-  "OnMessageReceived callback")]]
+  "libstatistics_collector::TopicStatisticsCollector alias instead")]]
   TopicStatisticsCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public collector::Collector
 {

--- a/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
@@ -82,7 +82,7 @@ class TopicStatisticsCollector<rmw_message_info_t,
 public:
   TopicStatisticsCollector() = default;
 
-  ~TopicStatisticsCollector() override = default;
+  virtual ~TopicStatisticsCollector() = default;
 
   /**
    * Handle receiving a single message of type rmw_message_info_t.

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -22,8 +22,7 @@
 
 namespace
 {
-using ReceivedMessageAgeCollector = libstatistics_collector::
-  topic_statistics_collector::ReceivedMessageAgeCollector<>;
+using ReceivedMessageAgeCollector = libstatistics_collector::ReceivedMessageAgeCollector;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
 constexpr const double kExpectedAverageMilliseconds{2000.0};

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -17,13 +17,7 @@
 #include <chrono>
 #include <string>
 
-#include "libstatistics_collector/msg/dummy_message.hpp"
-#include "libstatistics_collector/msg/dummy_custom_header_message.hpp"
-#include "libstatistics_collector/topic_statistics_collector/constants.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_age.hpp"
-
-#include "rcl/time.h"
-
 #include "rmw/types.h"
 
 namespace
@@ -115,8 +109,8 @@ TEST(ReceivedMessageAgeTest, TestAgeMeasurement) {
 }
 
 TEST(ReceivedMessageAgeTest, TestGetStatNameAndUnit) {
-  ReceivedMessageAgeCollector test_untyped_collector{};
+  ReceivedMessageAgeCollector test_collector{};
 
-  EXPECT_FALSE(test_untyped_collector.GetMetricName().empty());
-  EXPECT_FALSE(test_untyped_collector.GetMetricUnit().empty());
+  EXPECT_FALSE(test_collector.GetMetricName().empty());
+  EXPECT_FALSE(test_collector.GetMetricUnit().empty());
 }

--- a/test/topic_statistics_collector/test_received_message_period.cpp
+++ b/test/topic_statistics_collector/test_received_message_period.cpp
@@ -16,15 +16,10 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <string>
 #include <thread>
 
 #include "libstatistics_collector/moving_average_statistics/types.hpp"
-#include "libstatistics_collector/topic_statistics_collector/constants.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_period.hpp"
-
-#include "rcl/time.h"
-
 #include "rmw/types.h"
 
 namespace
@@ -33,7 +28,6 @@ using ReceivedMessagePeriodCollector =
   libstatistics_collector::topic_statistics_collector::ReceivedMessagePeriodCollector<>;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
-constexpr const int kDefaultMessage{42};
 constexpr const double kExpectedAverageMilliseconds{1000.0};
 constexpr const double kExpectedMinMilliseconds{1000.0};
 constexpr const double kExpectedMaxMilliseconds{1000.0};
@@ -68,10 +62,9 @@ TEST(ReceivedMessagePeriodTest, TestPeriodMeasurement) {
   EXPECT_EQ(kExpectedStandardDeviation, stats.standard_deviation);
 }
 
-
 TEST(ReceivedMessagePeriodTest, TestGetStatNameAndUnit) {
-  ReceivedMessagePeriodCollector untyped_test{};
+  ReceivedMessagePeriodCollector test{};
 
-  EXPECT_FALSE(untyped_test.GetMetricName().empty());
-  EXPECT_FALSE(untyped_test.GetMetricUnit().empty());
+  EXPECT_FALSE(test.GetMetricName().empty());
+  EXPECT_FALSE(test.GetMetricUnit().empty());
 }

--- a/test/topic_statistics_collector/test_received_message_period.cpp
+++ b/test/topic_statistics_collector/test_received_message_period.cpp
@@ -24,8 +24,7 @@
 
 namespace
 {
-using ReceivedMessagePeriodCollector =
-  libstatistics_collector::topic_statistics_collector::ReceivedMessagePeriodCollector<>;
+using ReceivedMessagePeriodCollector = libstatistics_collector::ReceivedMessagePeriodCollector;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
 constexpr const double kExpectedAverageMilliseconds{1000.0};


### PR DESCRIPTION
- Relates  https://github.com/ros-tooling/libstatistics_collector/pull/170

To be able to nicely deprecate partially templated specifications I have to add aliases outside of the `topic_statistics_collector` namespace e.g. `libstatistics_collector::ReceivedMessagePeriodCollector` 
IMO this is a better compromise than deprecation on callbacks only level.